### PR TITLE
Remove chown dependency from jenkins targer since it doesn't exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default: cmake-debug debug
-jenkins: clean cmake-debug debug test coverage cmake-release release lint chown
+jenkins: clean cmake-debug debug test coverage cmake-release release lint 
 
 cmake-debug:
 	mkdir -p build/debug && \


### PR DESCRIPTION
And I need to use "make jenkins -j 1" in the Jenkins configuration to force no parallel make execution. For some reason it is on by default on Jenkins but off on my PC. 