### PR TITLE
Correct the configuration for Sonar to show gtest and gcovr results.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,5 +4,5 @@ sonar.projectVersion=1.0
 sonar.sources=src
 sonar.tests=unittest
 sonar.sourceEncoding=UTF-8
-sonar.cfamily.googletest.reportsPath=gtest_unittest.xml
-sonar.cfamily.gcov.reportsPath=coverage.xml
+sonar.cxx.xunit.reportsPath=gtest_unittest.xml
+sonar.cxx.coverage.reportsPath=coverage.xml


### PR DESCRIPTION
I believe we have to use the cxx plugin to display gtest and gcovr results. For example, your original gcov.reportsPath only handles the native *.gcov output, not the XML one generated by gcovr. 